### PR TITLE
feat: allow contract change method to use empty object as a default

### DIFF
--- a/lib/contract.js
+++ b/lib/contract.js
@@ -95,7 +95,7 @@ class Contract {
             });
         });
     }
-    async _changeMethodRaw(methodName, args, options = {}) {
+    async _changeMethodRaw(methodName, args = {}, options = {}) {
         validateBNLike({ gas: options.gas, attachedDeposit: options.attachedDeposit });
         const result = await this.account.functionCall({
             contractId: this.contractId,
@@ -105,7 +105,7 @@ class Contract {
         });
         return result;
     }
-    async _changeMethod(methodName, args, options) {
+    async _changeMethod(methodName, args = {}, options) {
         const result = await this._changeMethodRaw(methodName, args, options);
         return providers_1.getTransactionLastResult(result);
     }

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -123,7 +123,7 @@ export class Contract {
         });
     }
 
-    private async _changeMethodRaw(methodName: string, args: object, options: ChangeMethodOptions = {}) {
+    private async _changeMethodRaw(methodName: string, args: object = {}, options: ChangeMethodOptions = {}) {
         validateBNLike({ gas: options.gas, attachedDeposit: options.attachedDeposit });
         const result = await this.account.functionCall({
             contractId: this.contractId,
@@ -135,7 +135,7 @@ export class Contract {
         return result;
     }
     
-    private async _changeMethod(methodName: string, args: object, options: ChangeMethodOptions) {
+    private async _changeMethod(methodName: string, args: object = {}, options: ChangeMethodOptions) {
         const result = await this._changeMethodRaw(methodName, args, options);
         return getTransactionLastResult(result);
     }


### PR DESCRIPTION
This way contract methods with no arguments can use the default.  E.g.

`contract.foo()` <--- Uses the default gas, etc.  

However, you still need to add the empty arg if using options, e.g.

`contract.foo({}, {gas: Gas.parse("100Tgas)})`