### PR TITLE
fix: don't use window in `new WalletConnection`

### DIFF
--- a/lib/wallet-account.js
+++ b/lib/wallet-account.js
@@ -38,16 +38,17 @@ const PENDING_ACCESS_KEY_PREFIX = 'pending_key'; // browser storage key for a pe
  */
 class WalletConnection {
     constructor(near, appKeyPrefix) {
+        const isBrowser = typeof window !== 'undefined';
         this._near = near;
         const authDataKey = appKeyPrefix + LOCAL_STORAGE_KEY_SUFFIX;
-        const authData = JSON.parse(window.localStorage.getItem(authDataKey));
+        const authData = isBrowser && JSON.parse(window.localStorage.getItem(authDataKey));
         this._networkId = near.config.networkId;
         this._walletBaseUrl = near.config.walletUrl;
         appKeyPrefix = appKeyPrefix || near.config.contractName || 'default';
         this._keyStore = near.connection.signer.keyStore;
         this._authData = authData || { allKeys: [] };
         this._authDataKey = authDataKey;
-        if (!this.isSignedIn()) {
+        if (isBrowser && !this.isSignedIn()) {
             this._completeSignInWithAccessKey();
         }
     }

--- a/src/wallet-account.ts
+++ b/src/wallet-account.ts
@@ -82,14 +82,15 @@ export class WalletConnection {
     constructor(near: Near, appKeyPrefix: string | null) {
         this._near = near;
         const authDataKey = appKeyPrefix + LOCAL_STORAGE_KEY_SUFFIX;
-        const authData = JSON.parse(window.localStorage.getItem(authDataKey));
+        const isBrowser = typeof window !== 'undefined';
+        const authData = isBrowser && JSON.parse(window.localStorage.getItem(authDataKey));
         this._networkId = near.config.networkId;
         this._walletBaseUrl = near.config.walletUrl;
         appKeyPrefix = appKeyPrefix || near.config.contractName || 'default';
         this._keyStore = (near.connection.signer as InMemorySigner).keyStore;
         this._authData = authData || { allKeys: [] };
         this._authDataKey = authDataKey;
-        if (!this.isSignedIn()) {
+        if (isBrowser && !this.isSignedIn()) {
             this._completeSignInWithAccessKey();
         }
     }


### PR DESCRIPTION
Quick workaround to address https://github.com/near/near-api-js/issues/747 until the larger https://github.com/near/near-api-js/pull/748 is dealt with

I have verified that this works in this https://github.com/AhaLabs/tenk-template-gatsby/commit/bdfd70d148bb9826e734f141cd964a89617c9284